### PR TITLE
Add `/refresh` Endpoint for Refreshing Tokens

### DIFF
--- a/api/controllers/auth_controller.js
+++ b/api/controllers/auth_controller.js
@@ -7,7 +7,7 @@ const bcrypt = require('bcrypt');
 const customer = require('../models/account_model');
 
 const jwt_options = {
-    expiresIn: "30d",
+    expiresIn: "1d",
     issuer: "https://deepmarket.cs.pdx.edu"
 };
 

--- a/api/controllers/auth_controller.js
+++ b/api/controllers/auth_controller.js
@@ -80,8 +80,8 @@ exports.logout = (req, res) => {
 exports.refresh = (req, res) => {
     console.log(req.user_id);
     let token = jwt.sign({id: req.user_id}, config.JWT_KEY, jwt_options);
-    let status = 200;
     let message = "Refresh successful";
+    let status = 200;
 
     res.status(status).json({
         success: true,

--- a/api/controllers/auth_controller.js
+++ b/api/controllers/auth_controller.js
@@ -2,9 +2,15 @@
 
 const config = require('../config/config');
 
-let jwt = require('jsonwebtoken');
-let bcrypt = require('bcrypt');
-let customer = require('../models/account_model');
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcrypt');
+const customer = require('../models/account_model');
+
+const jwt_options = {
+    expiresIn: "30d",
+    issuer: "https://deepmarket.cs.pdx.edu"
+};
+
 
 // Authenticate user; return token
 exports.login = (req, res) => {
@@ -33,7 +39,7 @@ exports.login = (req, res) => {
             message = "Login unsuccessful";
             bcrypt.compare(plaintext_password, user.password).then(auth => {
                 if(auth) {
-                    token = jwt.sign({id: user._id}, config.JWT_KEY);
+                    token = jwt.sign({id: user._id}, config.JWT_KEY, jwt_options);
                     message = "Login successful";
                 }
                 res.status(status).json({
@@ -69,4 +75,19 @@ exports.logout = (req, res) => {
         token: null,
         auth: false,
     })
+};
+
+exports.refresh = (req, res) => {
+    console.log(req.user_id);
+    let token = jwt.sign({id: req.user_id}, config.JWT_KEY, jwt_options);
+    let status = 200;
+    let message = "Refresh successful";
+
+    res.status(status).json({
+        success: true,
+        error: null,
+        message: message,
+        token: token,
+        auth: true,
+    });
 };

--- a/api/controllers/verifyToken.js
+++ b/api/controllers/verifyToken.js
@@ -9,7 +9,7 @@
 "use strict";
 
 const config = require('../config/config');
-let jwt = require('jsonwebtoken');
+const jwt = require('jsonwebtoken');
 
 function verifyToken(req, res, next) {
     let token = req.headers['x-access-token'];

--- a/api/routes/auth_route.js
+++ b/api/routes/auth_route.js
@@ -7,9 +7,10 @@ const config = require('../config/config');
 const verifyToken = require(`${config.CONTROLLERS_PATH}/verifyToken`);
 const authController = require(`${config.CONTROLLERS_PATH}/auth_controller`);
 
-/* Create a new customer */
 router.post('/login', authController.login);
 
 router.post('/logout', verifyToken, authController.logout);
+
+router.post('/refresh', verifyToken, authController.refresh);
 
 module.exports = router;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,21 @@
 version: "3"
 services:
 
+#  nginx:
+#    image: nginx:1.15-alpine
+#    ports:
+#      - "80:80"
+#      - "443:443"
+#    volumes:
+#      - ./conf/nginx:/etc/nginx/conf.d
+
   nginx:
-    image: nginx:1.15-alpine
+    image: owasp/modsecurity
     ports:
       - "80:80"
       - "443:443"
     volumes:
-      - ./conf/nginx:/etc/nginx/conf.d
+      - ./nginx:/etc/nginx/conf.d
 
   certbot:
       image: certbot/certbot

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "chai-http": "^4.0.0",
+    "jest": "^24.8.0",
     "mocha": "^5.0.1",
-    "should": "^13.2.1"
+    "should": "^13.2.1",
+    "sinon": "^7.3.2"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha --exit",


### PR DESCRIPTION
This PR adds functionality for:
*  A new endpoint `auth/refresh` which can be used for exchanging a valid token for another valid token with a current `iat` datetime.
* JWT payloads now include an `iss` and `exp` field for specifying token issuer and expiry, respectively.
* Other minor refactorings (e.g. changing `let` variables to `const`.