### PR TITLE
renaming staging container to avoid docker naming conflicts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     command: "npm start"
 
   stage:
-    container_name: deepshare_api
+    container_name: deepshare_api_staging
     image: "node"
     restart: always
 


### PR DESCRIPTION
latest staging container breaks `docker-compose up` as docker tries to run two containers with the same name